### PR TITLE
Remove 2018 fees

### DIFF
--- a/constants/fees.js
+++ b/constants/fees.js
@@ -1,8 +1,4 @@
 module.exports = {
-  2018: {
-    pel: 757,
-    pil: 257
-  },
   2019: {
     pel: 826,
     pil: 275


### PR DESCRIPTION
These need to be removed from the UI to avoid concerns with inconsistency with resolved invoices.