### PR TITLE
[ASL-4471] Add licence fees for 2024-25 financial year

### DIFF
--- a/constants/fees.js
+++ b/constants/fees.js
@@ -19,5 +19,9 @@ module.exports = {
   2023: {
     pel: 915,
     pil: 299
+  },
+  2024: {
+    pel: 915,
+    pil: 299
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/asl-constants",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Shared constants for ASL modules",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Add licence fees for 2024-25 financial year; Bump asl-constants from 2.1.3 to 2.1.4